### PR TITLE
Generate website performance graphs from sql data

### DIFF
--- a/reports/volume_report_demo.html
+++ b/reports/volume_report_demo.html
@@ -1,0 +1,78 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Volume Report 2025-08-01 to 2025-08-12 | Threshold: 10,000</title>
+<script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
+<style>
+body{font-family:Arial,Helvetica,sans-serif;margin:24px;}
+.grid{display:grid;grid-template-columns:1fr;gap:32px;}
+.sec{border:1px solid #eee;border-radius:8px;padding:16px;}
+.small{font-size:12px;color:#555}
+.table-wrapper{overflow:auto; max-height:420px;}
+ table{border-collapse:collapse;}
+ th, td{border:1px solid #ddd;padding:6px 8px;}
+ th{background:#fafafa;}
+</style>
+</head>
+<body>
+<h2>Volume Report 2025-08-01 to 2025-08-12 | Threshold: 10,000</h2>
+<div class="grid">
+  <div class="sec">
+    <h3>Higher vs Lower</h3>
+    <div id="chart_hilo"></div>
+  </div>
+  <div class="sec">
+    <h3>Top Higher Websites</h3>
+    <div id="chart_top_h"></div>
+  </div>
+  <div class="sec">
+    <h3>Top Lower Websites</h3>
+    <div id="chart_top_l"></div>
+  </div>
+  <div class="sec">
+    <h3>Best & Worst Performance</h3>
+    <div id="chart_best"></div>
+    <div id="chart_worst"></div>
+  </div>
+  <div class="sec">
+    <h3>Filtered Rows</h3>
+    <div class="table-wrapper">
+      <table>
+        <thead><tr><th>{c}</th><th>{c}</th><th>{c}</th><th>{c}</th><th>{c}</th><th>{c}</th></tr></thead>
+        <tbody>
+          <tr><td>2025-08-02</td><td>BOOKINGDOTCOM</td><td>100,116</td><td>133,879</td><td>-33,763</td><td>Lower</td></tr><tr><td>2025-08-03</td><td>BOOKINGDOTCOM</td><td>154,605</td><td>100,116</td><td>54,489</td><td>Higher</td></tr><tr><td>2025-08-04</td><td>BOOKINGDOTCOM</td><td>112,658</td><td>154,605</td><td>-41,947</td><td>Lower</td></tr><tr><td>2025-08-05</td><td>BOOKINGDOTCOM</td><td>153,587</td><td>112,658</td><td>40,929</td><td>Higher</td></tr><tr><td>2025-08-06</td><td>BOOKINGDOTCOM</td><td>124,384</td><td>153,587</td><td>-29,203</td><td>Lower</td></tr><tr><td>2025-08-07</td><td>BOOKINGDOTCOM</td><td>154,185</td><td>124,384</td><td>29,801</td><td>Higher</td></tr><tr><td>2025-08-08</td><td>BOOKINGDOTCOM</td><td>129,118</td><td>154,185</td><td>-25,067</td><td>Lower</td></tr><tr><td>2025-08-11</td><td>BOOKINGDOTCOM</td><td>99,717</td><td>122,604</td><td>-22,887</td><td>Lower</td></tr><tr><td>2025-08-12</td><td>BOOKINGDOTCOM</td><td>117,994</td><td>99,717</td><td>18,277</td><td>Higher</td></tr><tr><td>2025-08-02</td><td>BOOKINGMOBAPPCUG</td><td>142,092</td><td>131,359</td><td>10,733</td><td>Higher</td></tr><tr><td>2025-08-03</td><td>BOOKINGMOBAPPCUG</td><td>153,269</td><td>142,092</td><td>11,177</td><td>Higher</td></tr><tr><td>2025-08-05</td><td>BOOKINGMOBAPPCUG</td><td>110,875</td><td>154,570</td><td>-43,695</td><td>Lower</td></tr><tr><td>2025-08-07</td><td>BOOKINGMOBAPPCUG</td><td>141,809</td><td>113,656</td><td>28,153</td><td>Higher</td></tr><tr><td>2025-08-08</td><td>BOOKINGMOBAPPCUG</td><td>111,414</td><td>141,809</td><td>-30,395</td><td>Lower</td></tr><tr><td>2025-08-11</td><td>BOOKINGMOBAPPCUG</td><td>121,549</td><td>104,036</td><td>17,513</td><td>Higher</td></tr><tr><td>2025-08-12</td><td>BOOKINGMOBAPPCUG</td><td>141,090</td><td>121,549</td><td>19,541</td><td>Higher</td></tr><tr><td>2025-08-02</td><td>GOOGLEHPA</td><td>98,159</td><td>82,130</td><td>16,029</td><td>Higher</td></tr><tr><td>2025-08-03</td><td>GOOGLEHPA</td><td>113,096</td><td>98,159</td><td>14,937</td><td>Higher</td></tr><tr><td>2025-08-04</td><td>GOOGLEHPA</td><td>123,309</td><td>113,096</td><td>10,213</td><td>Higher</td></tr><tr><td>2025-08-05</td><td>GOOGLEHPA</td><td>95,086</td><td>123,309</td><td>-28,223</td><td>Lower</td></tr><tr><td>2025-08-06</td><td>GOOGLEHPA</td><td>84,155</td><td>95,086</td><td>-10,931</td><td>Lower</td></tr><tr><td>2025-08-07</td><td>GOOGLEHPA</td><td>96,324</td><td>84,155</td><td>12,169</td><td>Higher</td></tr><tr><td>2025-08-09</td><td>GOOGLEHPA</td><td>134,858</td><td>105,849</td><td>29,009</td><td>Higher</td></tr><tr><td>2025-08-10</td><td>GOOGLEHPA</td><td>81,031</td><td>134,858</td><td>-53,827</td><td>Lower</td></tr><tr><td>2025-08-11</td><td>GOOGLEHPA</td><td>111,008</td><td>81,031</td><td>29,977</td><td>Higher</td></tr><tr><td>2025-08-03</td><td>TRAVELOKAMOBAPP</td><td>132,762</td><td>115,921</td><td>16,841</td><td>Higher</td></tr><tr><td>2025-08-04</td><td>TRAVELOKAMOBAPP</td><td>117,231</td><td>132,762</td><td>-15,531</td><td>Lower</td></tr><tr><td>2025-08-05</td><td>TRAVELOKAMOBAPP</td><td>162,240</td><td>117,231</td><td>45,009</td><td>Higher</td></tr><tr><td>2025-08-06</td><td>TRAVELOKAMOBAPP</td><td>113,469</td><td>162,240</td><td>-48,771</td><td>Lower</td></tr><tr><td>2025-08-07</td><td>TRAVELOKAMOBAPP</td><td>142,550</td><td>113,469</td><td>29,081</td><td>Higher</td></tr><tr><td>2025-08-08</td><td>TRAVELOKAMOBAPP</td><td>131,803</td><td>142,550</td><td>-10,747</td><td>Lower</td></tr><tr><td>2025-08-10</td><td>TRAVELOKAMOBAPP</td><td>127,913</td><td>138,524</td><td>-10,611</td><td>Lower</td></tr><tr><td>2025-08-02</td><td>EXPEDIA</td><td>124,643</td><td>170,950</td><td>-46,307</td><td>Lower</td></tr><tr><td>2025-08-04</td><td>EXPEDIA</td><td>158,177</td><td>130,396</td><td>27,781</td><td>Higher</td></tr><tr><td>2025-08-05</td><td>EXPEDIA</td><td>136,546</td><td>158,177</td><td>-21,631</td><td>Lower</td></tr><tr><td>2025-08-06</td><td>EXPEDIA</td><td>122,127</td><td>136,546</td><td>-14,419</td><td>Lower</td></tr><tr><td>2025-08-07</td><td>EXPEDIA</td><td>152,280</td><td>122,127</td><td>30,153</td><td>Higher</td></tr><tr><td>2025-08-10</td><td>EXPEDIA</td><td>167,387</td><td>141,886</td><td>25,501</td><td>Higher</td></tr><tr><td>2025-08-12</td><td>EXPEDIA</td><td>147,577</td><td>171,156</td><td>-23,579</td><td>Lower</td></tr><tr><td>2025-08-02</td><td>EXPEDIAMOCUG</td><td>137,295</td><td>167,106</td><td>-29,811</td><td>Lower</td></tr><tr><td>2025-08-04</td><td>EXPEDIAMOCUG</td><td>109,261</td><td>146,392</td><td>-37,131</td><td>Lower</td></tr><tr><td>2025-08-05</td><td>EXPEDIAMOCUG</td><td>155,006</td><td>109,261</td><td>45,745</td><td>Higher</td></tr><tr><td>2025-08-06</td><td>EXPEDIAMOCUG</td><td>135,099</td><td>155,006</td><td>-19,907</td><td>Lower</td></tr><tr><td>2025-08-07</td><td>EXPEDIAMOCUG</td><td>159,508</td><td>135,099</td><td>24,409</td><td>Higher</td></tr><tr><td>2025-08-09</td><td>EXPEDIAMOCUG</td><td>111,546</td><td>158,649</td><td>-47,103</td><td>Lower</td></tr><tr><td>2025-08-10</td><td>EXPEDIAMOCUG</td><td>124,007</td><td>111,546</td><td>12,461</td><td>Higher</td></tr><tr><td>2025-08-11</td><td>EXPEDIAMOCUG</td><td>158,768</td><td>124,007</td><td>34,761</td><td>Higher</td></tr><tr><td>2025-08-12</td><td>EXPEDIAMOCUG</td><td>129,541</td><td>158,768</td><td>-29,227</td><td>Lower</td></tr><tr><td>2025-08-02</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>134,610</td><td>124,533</td><td>10,077</td><td>Higher</td></tr><tr><td>2025-08-03</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>102,699</td><td>134,610</td><td>-31,911</td><td>Lower</td></tr><tr><td>2025-08-05</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>158,353</td><td>105,136</td><td>53,217</td><td>Higher</td></tr><tr><td>2025-08-06</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>117,502</td><td>158,353</td><td>-40,851</td><td>Lower</td></tr><tr><td>2025-08-08</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>136,956</td><td>108,967</td><td>27,989</td><td>Higher</td></tr><tr><td>2025-08-09</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>119,149</td><td>136,956</td><td>-17,807</td><td>Lower</td></tr><tr><td>2025-08-10</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>143,978</td><td>119,149</td><td>24,829</td><td>Higher</td></tr><tr><td>2025-08-11</td><td>MAKEMYTRIPANDROIDMOBAPP</td><td>129,219</td><td>143,978</td><td>-14,759</td><td>Lower</td></tr><tr><td>2025-08-02</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>174,243</td><td>127,574</td><td>46,669</td><td>Higher</td></tr><tr><td>2025-08-03</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>162,636</td><td>174,243</td><td>-11,607</td><td>Lower</td></tr><tr><td>2025-08-06</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>174,575</td><td>161,010</td><td>13,565</td><td>Higher</td></tr><tr><td>2025-08-07</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>148,872</td><td>174,575</td><td>-25,703</td><td>Lower</td></tr><tr><td>2025-08-08</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>118,413</td><td>148,872</td><td>-30,459</td><td>Lower</td></tr><tr><td>2025-08-09</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>159,854</td><td>118,413</td><td>41,441</td><td>Higher</td></tr><tr><td>2025-08-10</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>131,291</td><td>159,854</td><td>-28,563</td><td>Lower</td></tr><tr><td>2025-08-12</td><td>MAKEMYTRIPANDROIDMOBAPPCUGAG</td><td>149,753</td><td>130,852</td><td>18,901</td><td>Higher</td></tr><tr><td>2025-08-02</td><td>MAKEMYTRIPCTH</td><td>154,043</td><td>123,806</td><td>30,237</td><td>Higher</td></tr><tr><td>2025-08-03</td><td>MAKEMYTRIPCTH</td><td>135,668</td><td>154,043</td><td>-18,375</td><td>Lower</td></tr><tr><td>2025-08-04</td><td>MAKEMYTRIPCTH</td><td>165,049</td><td>135,668</td><td>29,381</td><td>Higher</td></tr><tr><td>2025-08-05</td><td>MAKEMYTRIPCTH</td><td>152,282</td><td>165,049</td><td>-12,767</td><td>Lower</td></tr><tr><td>2025-08-06</td><td>MAKEMYTRIPCTH</td><td>121,607</td><td>152,282</td><td>-30,675</td><td>Lower</td></tr><tr><td>2025-08-08</td><td>MAKEMYTRIPCTH</td><td>145,253</td><td>114,384</td><td>30,869</td><td>Higher</td></tr><tr><td>2025-08-09</td><td>MAKEMYTRIPCTH</td><td>130,966</td><td>145,253</td><td>-14,287</td><td>Lower</td></tr><tr><td>2025-08-12</td><td>MAKEMYTRIPCTH</td><td>136,881</td><td>121,676</td><td>15,205</td><td>Higher</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<p class="small">Generated at 2025-08-13 06:39:41</p>
+<script>
+  const dates = ['2025-08-02', '2025-08-03', '2025-08-04', '2025-08-05', '2025-08-06', '2025-08-07', '2025-08-08', '2025-08-09', '2025-08-10', '2025-08-11', '2025-08-12'];
+  const higher = [5, 4, 3, 4, 1, 6, 2, 2, 3, 3, 4];
+  const lower = [3, 3, 3, 4, 7, 1, 4, 3, 3, 2, 2];
+  Plotly.newPlot('chart_hilo', [
+    {x: dates, y: higher, type: 'bar', name: 'Higher', marker: {color: '#2ca02c'}},
+    {x: dates, y: lower, type: 'bar', name: 'Lower', marker: {color: '#d62728'}},
+  ], {barmode:'group', title:'Higher vs Lower counts per day'});
+
+  Plotly.newPlot('chart_top_h', [
+    {x: ['BOOKINGDOTCOM', 'MAKEMYTRIPANDROIDMOBAPPCUGAG', 'EXPEDIAMOCUG', 'MAKEMYTRIPANDROIDMOBAPP', 'GOOGLEHPA', 'MAKEMYTRIPCTH', 'TRAVELOKAMOBAPP', 'BOOKINGMOBAPPCUG', 'EXPEDIA'], y: [143496, 120576, 117376, 116112, 112334, 105692, 90931, 87117, 83435], type:'bar', marker: {color:'#1f77b4'}}
+  ], {title: 'Top Higher Websites by total abs diff'});
+
+  Plotly.newPlot('chart_top_l', [
+    {x: ['EXPEDIAMOCUG', 'BOOKINGDOTCOM', 'EXPEDIA', 'MAKEMYTRIPANDROIDMOBAPP', 'MAKEMYTRIPANDROIDMOBAPPCUGAG', 'GOOGLEHPA', 'TRAVELOKAMOBAPP', 'MAKEMYTRIPCTH', 'BOOKINGMOBAPPCUG'], y: [163179, 152867, 105936, 105328, 96332, 92981, 85660, 76104, 74090], type:'bar', marker: {color:'#9467bd'}}
+  ], {title: 'Top Lower Websites by total abs diff'});
+
+  Plotly.newPlot('chart_best', [
+    {x: ['MAKEMYTRIPCTH', 'MAKEMYTRIPANDROIDMOBAPPCUGAG', 'GOOGLEHPA', 'BOOKINGMOBAPPCUG', 'MAKEMYTRIPANDROIDMOBAPP', 'TRAVELOKAMOBAPP', 'BOOKINGDOTCOM', 'EXPEDIA', 'EXPEDIAMOCUG'], y: [29588, 24244, 19353, 13027, 10784, 5271, -9371, -22501, -45803], type:'bar', marker: {color:'#2ca02c'}}
+  ], {title: 'Best (Cumulative Increase)'});
+
+  Plotly.newPlot('chart_worst', [
+    {x: ['EXPEDIAMOCUG', 'EXPEDIA', 'BOOKINGDOTCOM', 'TRAVELOKAMOBAPP', 'MAKEMYTRIPANDROIDMOBAPP', 'BOOKINGMOBAPPCUG', 'GOOGLEHPA', 'MAKEMYTRIPANDROIDMOBAPPCUGAG', 'MAKEMYTRIPCTH'], y: [-45803, -22501, -9371, 5271, 10784, 13027, 19353, 24244, 29588], type:'bar', marker: {color:'#d62728'}}
+  ], {title: 'Worst (Cumulative Decrease)'});
+</script>
+</body>
+</html>

--- a/volume_report/README.md
+++ b/volume_report/README.md
@@ -1,0 +1,48 @@
+# Volume Comparison Report
+
+Generates an interactive HTML report from the daily website volume table. It dynamically filters by date range and threshold, and creates:
+
+- Higher vs Lower daily counts
+- Top Higher websites
+- Top Lower websites
+- Best & Worst performance websites (cumulative diff)
+
+## Requirements
+
+Install Python packages:
+
+```bash
+pip install -r /workspace/volume_report/requirements.txt
+```
+
+## Run (Demo Mode)
+
+Produces a sample report without DB access:
+
+```bash
+python /workspace/volume_report/report.py --demo --start-date 2025-08-01 --end-date 2025-08-12 --threshold 10000 --output /workspace/reports/volume_report_demo.html
+```
+
+Open the generated HTML in your browser.
+
+## Run (SQL Server)
+
+Supply connection parameters. Dates and threshold are dynamic.
+
+```bash
+python /workspace/volume_report/report.py \
+  --server YOUR_SQL_HOST \
+  --database YOUR_DB \
+  --username USERNAME \
+  --password PASSWORD \
+  --start-date 2025-08-01 \
+  --end-date 2025-08-12 \
+  --threshold 10000 \
+  --table RG_AgodaDaily_WebsiteWiseStats \
+  --output /workspace/reports/volume_report.html
+```
+
+Notes:
+- Uses a CTE equivalent to your provided query and applies `ABS(volume_diff) >= threshold`.
+- Set `--driver "ODBC Driver 17 for SQL Server"` if needed on your system, and add `--trust-cert` if your server requires it.
+- The output HTML embeds Plotly charts with CDN resources, so viewing requires internet access.

--- a/volume_report/report.py
+++ b/volume_report/report.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+import textwrap
+from datetime import datetime, date
+from typing import Optional, Tuple
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+# Optional imports for SQL connectivity
+try:
+    from sqlalchemy import create_engine, text as sql_text
+except Exception:
+    create_engine = None  # type: ignore
+    sql_text = None  # type: ignore
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate volume comparison report from SQL Server data and output an interactive HTML.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--start-date", required=False, help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end-date", required=False, help="End date (YYYY-MM-DD)")
+    parser.add_argument("--threshold", type=int, default=10000, help="Absolute daily diff threshold for inclusion")
+
+    # SQL connection options
+    parser.add_argument("--server", help="SQL Server hostname or IP")
+    parser.add_argument("--database", help="Database name")
+    parser.add_argument("--username", help="Username for SQL Server")
+    parser.add_argument("--password", help="Password for SQL Server")
+    parser.add_argument("--driver", default="ODBC Driver 17 for SQL Server", help="ODBC driver for pyodbc connection string")
+    parser.add_argument("--trust-cert", action="store_true", help="Trust server certificate (add TrustServerCertificate=yes)")
+
+    parser.add_argument("--output", default="/workspace/reports/volume_report.html", help="Output HTML path")
+    parser.add_argument("--table", default="RG_AgodaDaily_WebsiteWiseStats", help="Source table name")
+    parser.add_argument("--demo", action="store_true", help="Run with generated demo data instead of DB")
+
+    return parser.parse_args()
+
+
+def parse_date(d: Optional[str], default: Optional[date]) -> Optional[date]:
+    if d is None:
+        return default
+    return datetime.strptime(d, "%Y-%m-%d").date()
+
+
+def validate_dates(start: Optional[date], end: Optional[date]) -> Tuple[Optional[date], Optional[date]]:
+    if start and end and start > end:
+        raise ValueError("start-date must be <= end-date")
+    return start, end
+
+
+def build_query(table: str, start: Optional[date], end: Optional[date], threshold: int) -> str:
+    # Convert to SQL literals
+    where_parts = ["AssignmentDate IS NOT NULL"]
+    if start is not None:
+        where_parts.append(f"AssignmentDate >= '{start.strftime('%Y-%m-%d')}'")
+    if end is not None:
+        where_parts.append(f"AssignmentDate <= '{end.strftime('%Y-%m-%d')}'")
+    where_clause = " AND ".join(where_parts)
+
+    # Compose query using a CTE as provided
+    query = f"""
+    WITH volume_comparison AS (
+        SELECT
+            AssignmentDate,
+            website,
+            TotalRequest,
+            LAG(TotalRequest) OVER (PARTITION BY website ORDER BY AssignmentDate) AS prev_day_volume,
+            TotalRequest - LAG(TotalRequest) OVER (PARTITION BY website ORDER BY AssignmentDate) AS volume_diff,
+            CASE
+                WHEN TotalRequest - LAG(TotalRequest) OVER (PARTITION BY website ORDER BY AssignmentDate) > 0 THEN 'Higher'
+                WHEN TotalRequest - LAG(TotalRequest) OVER (PARTITION BY website ORDER BY AssignmentDate) < 0 THEN 'Lower'
+                ELSE 'Same'
+            END AS volume_status
+        FROM {table} WITH (NOLOCK)
+        WHERE {where_clause}
+    )
+    SELECT AssignmentDate, website, TotalRequest, prev_day_volume, volume_diff, volume_status
+    FROM volume_comparison
+    WHERE prev_day_volume IS NOT NULL AND ABS(volume_diff) >= {threshold}
+    ORDER BY AssignmentDate, website;
+    """
+    return query
+
+
+def build_engine(server: str, database: str, username: Optional[str], password: Optional[str], driver: str, trust_cert: bool):
+    if create_engine is None:
+        raise RuntimeError("SQLAlchemy is not available. Please install requirements.")
+
+    # Prefer pyodbc connection string through SQLAlchemy
+    params = {
+        "DRIVER": driver,
+        "SERVER": server,
+        "DATABASE": database,
+    }
+    if username and password:
+        params.update({"UID": username, "PWD": password})
+    else:
+        # Trusted connection (Linux + Kerberos not typical). Keeping UID/PWD optional.
+        pass
+    if trust_cert:
+        params["TrustServerCertificate"] = "yes"
+
+    # Encode into URL form
+    # mssql+pyodbc:///?odbc_connect=...
+    import urllib.parse
+
+    odbc_parts = ";".join([f"{k}={v}" for k, v in params.items()])
+    odbc_connect = urllib.parse.quote_plus(odbc_parts)
+    url = f"mssql+pyodbc:///?odbc_connect={odbc_connect}"
+    engine = create_engine(url, fast_executemany=True)
+    return engine
+
+
+def fetch_data(engine, query: str) -> pd.DataFrame:
+    with engine.connect() as conn:
+        df = pd.read_sql_query(sql_text(query), conn)  # type: ignore
+    # Enforce dtypes
+    if not pd.api.types.is_datetime64_any_dtype(df["AssignmentDate"]):
+        df["AssignmentDate"] = pd.to_datetime(df["AssignmentDate"]).dt.date
+    return df
+
+
+def demo_data() -> pd.DataFrame:
+    # Create simulated sample across dates and websites
+    rng = pd.date_range("2025-08-01", "2025-08-12", freq="D").date
+    websites = [
+        "BOOKINGDOTCOM",
+        "BOOKINGMOBAPPCUG",
+        "GOOGLEHPA",
+        "TRAVELOKAMOBAPP",
+        "EXPEDIA",
+        "EXPEDIAMOCUG",
+        "MAKEMYTRIPANDROIDMOBAPP",
+        "MAKEMYTRIPANDROIDMOBAPPCUGAG",
+        "MAKEMYTRIPCTH",
+    ]
+    rows = []
+    seed = 42
+    for ws in websites:
+        base = 100000 + (hash(ws) % 50000)
+        last = None
+        for d in rng:
+            # deterministic pseudo random
+            seed = (seed * 1103515245 + 12345) & 0x7FFFFFFF
+            delta = (seed % 60000) - 30000  # -30k .. +30k
+            vol = max(10000, base + delta)
+            if last is None:
+                prev = None
+                diff = None
+            else:
+                prev = last
+                diff = vol - last
+            rows.append({
+                "AssignmentDate": d,
+                "website": ws,
+                "TotalRequest": vol,
+                "prev_day_volume": prev,
+                "volume_diff": diff,
+                "volume_status": (
+                    "Higher" if diff is not None and diff > 0 else ("Lower" if diff is not None and diff < 0 else "Same")
+                ),
+            })
+            last = vol
+    df = pd.DataFrame(rows)
+    df = df[df["prev_day_volume"].notna()].copy()
+    df["volume_diff_abs"] = df["volume_diff"].abs()
+    df = df[df["volume_diff_abs"] >= 10000]
+    return df.drop(columns=["volume_diff_abs"])  # will recompute based on threshold later
+
+
+def filter_threshold(df: pd.DataFrame, threshold: int) -> pd.DataFrame:
+    mask = df["volume_diff"].abs() >= threshold
+    return df.loc[mask].copy()
+
+
+def format_number(n: float) -> str:
+    return f"{n:,.0f}"
+
+
+def chart_higher_vs_lower(df: pd.DataFrame):
+    counts = df.groupby(["AssignmentDate", "volume_status"], as_index=False)["website"].count()
+    counts.rename(columns={"website": "count"}, inplace=True)
+    # Keep only Higher/Lower for the stacked chart
+    counts = counts[counts["volume_status"].isin(["Higher", "Lower"])]
+    fig = px.bar(
+        counts,
+        x="AssignmentDate",
+        y="count",
+        color="volume_status",
+        barmode="group",
+        color_discrete_map={"Higher": "#2ca02c", "Lower": "#d62728"},
+        title="Higher vs Lower counts per day",
+    )
+    fig.update_layout(legend_title_text="Status", bargap=0.2)
+    return fig
+
+
+def chart_top_websites(df: pd.DataFrame, status: str, top_n: int = 10):
+    sub = df[df["volume_status"] == status].copy()
+    if sub.empty:
+        return go.Figure()
+    # Sum absolute diffs by website across the period
+    agg = (
+        sub.assign(abs_diff=sub["volume_diff"].abs())
+        .groupby("website", as_index=False)["abs_diff"].sum()
+        .sort_values("abs_diff", ascending=False)
+        .head(top_n)
+    )
+    fig = px.bar(
+        agg,
+        x="website",
+        y="abs_diff",
+        title=f"Top {top_n} websites by total absolute diff ({status})",
+        labels={"abs_diff": "Total Abs Diff"},
+        color_discrete_sequence=["#1f77b4"],
+    )
+    fig.update_yaxes(tickformat=",")
+    fig.update_xaxes(tickangle=30)
+    return fig
+
+
+def chart_best_worst_websites(df: pd.DataFrame, top_n: int = 10):
+    # Best: most positive cumulative diff; Worst: most negative cumulative diff
+    agg = df.groupby("website", as_index=False)["volume_diff"].sum()
+    best = agg.sort_values("volume_diff", ascending=False).head(top_n)
+    worst = agg.sort_values("volume_diff").head(top_n)
+
+    fig = make_subplots(rows=1, cols=2, subplot_titles=("Best (Cumulative Increase)", "Worst (Cumulative Decrease)"))
+
+    fig.add_trace(
+        go.Bar(x=best["website"], y=best["volume_diff"], marker_color="#2ca02c", name="Best"),
+        row=1, col=1
+    )
+    fig.add_trace(
+        go.Bar(x=worst["website"], y=worst["volume_diff"], marker_color="#d62728", name="Worst"),
+        row=1, col=2
+    )
+    fig.update_layout(title_text="Best and Worst Performance Websites (Cumulative Diff)")
+    fig.update_yaxes(tickformat=",")
+    fig.update_xaxes(tickangle=30)
+    return fig
+
+
+def build_report(df: pd.DataFrame, output_path: str, start: Optional[date], end: Optional[date], threshold: int, sql_info: Optional[str] = None):
+    if df.empty:
+        html = f"""
+        <html><head><meta charset='utf-8'><title>Volume Report</title></head>
+        <body>
+            <h2>Volume Report</h2>
+            <p>No data after applying filters.</p>
+        </body></html>
+        """
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(html)
+        return output_path
+
+    df = df.copy()
+    # Ensure date order
+    df["AssignmentDate"] = pd.to_datetime(df["AssignmentDate"]).dt.date
+
+    # Charts
+    higher_lower_fig = chart_higher_vs_lower(df)
+    top_higher_fig = chart_top_websites(df, status="Higher")
+    top_lower_fig = chart_top_websites(df, status="Lower")
+    best_worst_fig = chart_best_worst_websites(df)
+
+    # Build HTML
+    start_str = start.isoformat() if start else "(min)"
+    end_str = end.isoformat() if end else "(max)"
+    title = f"Volume Report {start_str} to {end_str} | Threshold: {threshold:,}"
+
+    html_parts = [
+        "<html>",
+        "<head>",
+        "<meta charset='utf-8'>",
+        f"<title>{title}</title>",
+        "<style>body{font-family:Arial,Helvetica,sans-serif;margin:24px;} h2{margin-top:0} .meta{color:#666} .grid{display:grid;grid-template-columns:1fr;gap:32px;} .sec{border:1px solid #eee;border-radius:8px;padding:16px;} .small{font-size:12px;color:#555}</style>",
+        "</head>",
+        "<body>",
+        f"<h2>{title}</h2>",
+    ]
+    if sql_info:
+        html_parts.append(f"<p class='meta'>{sql_info}</p>")
+
+    # Embed figures
+    def fig_div(fig):
+        return fig.to_html(include_plotlyjs='cdn', full_html=False)
+
+    html_parts.extend([
+        "<div class='grid'>",
+        "<div class='sec'>",
+        "<h3>Higher vs Lower</h3>",
+        fig_div(higher_lower_fig),
+        "</div>",
+        "<div class='sec'>",
+        "<h3>Top Higher Websites</h3>",
+        fig_div(top_higher_fig),
+        "</div>",
+        "<div class='sec'>",
+        "<h3>Top Lower Websites</h3>",
+        fig_div(top_lower_fig),
+        "</div>",
+        "<div class='sec'>",
+        "<h3>Best & Worst Performance</h3>",
+        fig_div(best_worst_fig),
+        "</div>",
+        "</div>",
+    ])
+
+    # Tabular preview
+    preview = df.copy()
+    preview["TotalRequest"] = preview["TotalRequest"].map(format_number)
+    preview["prev_day_volume"] = preview["prev_day_volume"].map(lambda v: "" if pd.isna(v) else format_number(float(v)))
+    preview["volume_diff"] = preview["volume_diff"].map(lambda v: format_number(v) if pd.notna(v) else "")
+    html_parts.append("<div class='sec'>")
+    html_parts.append("<h3>Filtered Rows</h3>")
+    html_parts.append(preview.to_html(index=False))
+    html_parts.append("</div>")
+
+    html_parts.append("<p class='small'>Generated at " + datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "</p>")
+    html_parts.append("</body></html>")
+
+    html = "\n".join(html_parts)
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+    return output_path
+
+
+def main():
+    args = parse_args()
+    # Dates
+    default_end = date.today()
+    default_start = default_end.replace(day=1)
+
+    start = parse_date(args.start_date, default_start)
+    end = parse_date(args.end_date, default_end)
+    start, end = validate_dates(start, end)
+
+    threshold = int(args.threshold)
+
+    if args.demo:
+        df = demo_data()
+        df = filter_threshold(df, threshold)
+        output = build_report(df, args.output, start, end, threshold, sql_info="Demo mode")
+        print(output)
+        return 0
+
+    # Ensure required SQL params
+    missing = [name for name, val in {
+        "server": args.server,
+        "database": args.database,
+    }.items() if not val]
+    if missing:
+        print("Missing required arguments: " + ", ".join(missing), file=sys.stderr)
+        return 2
+
+    engine = build_engine(
+        server=args.server,
+        database=args.database,
+        username=args.username,
+        password=args.password,
+        driver=args.driver,
+        trust_cert=args.trust_cert,
+    )
+
+    query = build_query(args.table, start, end, threshold)
+    df = fetch_data(engine, query)
+    df = filter_threshold(df, threshold)
+
+    sql_info = f"Server={args.server}; Database={args.database}; Table={args.table}"
+    output = build_report(df, args.output, start, end, threshold, sql_info=sql_info)
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/volume_report/report_standalone.py
+++ b/volume_report/report_standalone.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from datetime import date, datetime
+from typing import List, Dict, Optional
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Generate volume comparison HTML report (no external Python deps).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--start-date", help="Start date (YYYY-MM-DD)")
+    p.add_argument("--end-date", help="End date (YYYY-MM-DD)")
+    p.add_argument("--threshold", type=int, default=10000, help="Absolute diff threshold")
+    p.add_argument("--output", default="/workspace/reports/volume_report_demo.html", help="Output HTML path")
+    p.add_argument("--demo", action="store_true", help="Use generated data (default)")
+    return p.parse_args()
+
+
+def to_date(s: Optional[str], default: Optional[date]) -> Optional[date]:
+    if s is None:
+        return default
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def demo_rows() -> List[Dict]:
+    # Generate deterministic demo data across dates and websites
+    rng = [date(2025, 8, d) for d in range(1, 13)]
+    websites = [
+        "BOOKINGDOTCOM",
+        "BOOKINGMOBAPPCUG",
+        "GOOGLEHPA",
+        "TRAVELOKAMOBAPP",
+        "EXPEDIA",
+        "EXPEDIAMOCUG",
+        "MAKEMYTRIPANDROIDMOBAPP",
+        "MAKEMYTRIPANDROIDMOBAPPCUGAG",
+        "MAKEMYTRIPCTH",
+    ]
+    rows: List[Dict] = []
+    seed = 42
+    for ws in websites:
+        base = 100000 + (hash(ws) % 50000)
+        last: Optional[int] = None
+        for d in rng:
+            seed = (seed * 1103515245 + 12345) & 0x7FFFFFFF
+            delta = (seed % 60000) - 30000  # -30k..+30k
+            vol = max(10000, base + delta)
+            if last is None:
+                prev = None
+                diff = None
+                status = "Same"
+            else:
+                prev = last
+                diff = vol - last
+                status = "Higher" if diff > 0 else ("Lower" if diff < 0 else "Same")
+            rows.append(
+                {
+                    "AssignmentDate": d.isoformat(),
+                    "website": ws,
+                    "TotalRequest": vol,
+                    "prev_day_volume": prev,
+                    "volume_diff": diff,
+                    "volume_status": status,
+                }
+            )
+            last = vol
+    # Drop first day (no prev)
+    rows = [r for r in rows if r["prev_day_volume"] is not None]
+    return rows
+
+
+def filter_rows(rows: List[Dict], threshold: int) -> List[Dict]:
+    return [r for r in rows if abs(int(r["volume_diff"])) >= threshold]
+
+
+def group_counts_by_date_and_status(rows: List[Dict]):
+    counts = {}
+    for r in rows:
+        key = (r["AssignmentDate"], r["volume_status"])
+        counts[key] = counts.get(key, 0) + 1
+    # Return sorted arrays
+    dates = sorted({d for d, _ in counts.keys()})
+    higher = [counts.get((d, "Higher"), 0) for d in dates]
+    lower = [counts.get((d, "Lower"), 0) for d in dates]
+    return dates, higher, lower
+
+
+def top_websites_by_abs_diff(rows: List[Dict], status: str, top_n: int = 10):
+    totals = {}
+    for r in rows:
+        if r["volume_status"] != status:
+            continue
+        totals[r["website"]] = totals.get(r["website"], 0) + abs(int(r["volume_diff"]))
+    items = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+    names = [k for k, _ in items]
+    values = [v for _, v in items]
+    return names, values
+
+
+def best_worst(rows: List[Dict], top_n: int = 10):
+    totals = {}
+    for r in rows:
+        totals[r["website"]] = totals.get(r["website"], 0) + int(r["volume_diff"])
+    items = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
+    best = items[:top_n]
+    worst = items[-top_n:][::-1]
+    return ([k for k, _ in best], [v for _, v in best], [k for k, _ in worst], [v for _, v in worst])
+
+
+def number(x: int) -> str:
+    return f"{x:,}"
+
+
+def build_html(rows: List[Dict], output_path: str, start: Optional[date], end: Optional[date], threshold: int):
+    dates, higher_counts, lower_counts = group_counts_by_date_and_status(rows)
+    top_h_names, top_h_vals = top_websites_by_abs_diff(rows, "Higher")
+    top_l_names, top_l_vals = top_websites_by_abs_diff(rows, "Lower")
+    b_names, b_vals, w_names, w_vals = best_worst(rows)
+
+    start_str = start.isoformat() if start else "(min)"
+    end_str = end.isoformat() if end else "(max)"
+    title = f"Volume Report {start_str} to {end_str} | Threshold: {threshold:,}"
+
+    # Tabular preview HTML
+    header = ["AssignmentDate", "website", "TotalRequest", "prev_day_volume", "volume_diff", "volume_status"]
+    table_rows = []
+    for r in rows:
+        table_rows.append(
+            "<tr>"
+            + f"<td>{r['AssignmentDate']}</td>"
+            + f"<td>{r['website']}</td>"
+            + f"<td>{number(int(r['TotalRequest']))}</td>"
+            + f"<td>{number(int(r['prev_day_volume']))}</td>"
+            + f"<td>{number(int(r['volume_diff']))}</td>"
+            + f"<td>{r['volume_status']}</td>"
+            + "</tr>"
+        )
+
+    html = f"""
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>{title}</title>
+<script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
+<style>
+body{{font-family:Arial,Helvetica,sans-serif;margin:24px;}}
+.grid{{display:grid;grid-template-columns:1fr;gap:32px;}}
+.sec{{border:1px solid #eee;border-radius:8px;padding:16px;}}
+.small{{font-size:12px;color:#555}}
+.table-wrapper{{overflow:auto; max-height:420px;}}
+ table{{border-collapse:collapse;}}
+ th, td{{border:1px solid #ddd;padding:6px 8px;}}
+ th{{background:#fafafa;}}
+</style>
+</head>
+<body>
+<h2>{title}</h2>
+<div class="grid">
+  <div class="sec">
+    <h3>Higher vs Lower</h3>
+    <div id="chart_hilo"></div>
+  </div>
+  <div class="sec">
+    <h3>Top Higher Websites</h3>
+    <div id="chart_top_h"></div>
+  </div>
+  <div class="sec">
+    <h3>Top Lower Websites</h3>
+    <div id="chart_top_l"></div>
+  </div>
+  <div class="sec">
+    <h3>Best & Worst Performance</h3>
+    <div id="chart_best"></div>
+    <div id="chart_worst"></div>
+  </div>
+  <div class="sec">
+    <h3>Filtered Rows</h3>
+    <div class="table-wrapper">
+      <table>
+        <thead><tr>{''.join(f'<th>{{c}}</th>' for c in header)}</tr></thead>
+        <tbody>
+          {''.join(table_rows)}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<p class="small">Generated at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</p>
+<script>
+  const dates = {dates};
+  const higher = {higher_counts};
+  const lower = {lower_counts};
+  Plotly.newPlot('chart_hilo', [
+    {{x: dates, y: higher, type: 'bar', name: 'Higher', marker: {{color: '#2ca02c'}}}},
+    {{x: dates, y: lower, type: 'bar', name: 'Lower', marker: {{color: '#d62728'}}}},
+  ], {{barmode:'group', title:'Higher vs Lower counts per day'}});
+
+  Plotly.newPlot('chart_top_h', [
+    {{x: {top_h_names}, y: {top_h_vals}, type:'bar', marker: {{color:'#1f77b4'}}}}
+  ], {{title: 'Top Higher Websites by total abs diff'}});
+
+  Plotly.newPlot('chart_top_l', [
+    {{x: {top_l_names}, y: {top_l_vals}, type:'bar', marker: {{color:'#9467bd'}}}}
+  ], {{title: 'Top Lower Websites by total abs diff'}});
+
+  Plotly.newPlot('chart_best', [
+    {{x: {b_names}, y: {b_vals}, type:'bar', marker: {{color:'#2ca02c'}}}}
+  ], {{title: 'Best (Cumulative Increase)'}});
+
+  Plotly.newPlot('chart_worst', [
+    {{x: {w_names}, y: {w_vals}, type:'bar', marker: {{color:'#d62728'}}}}
+  ], {{title: 'Worst (Cumulative Decrease)'}});
+</script>
+</body>
+</html>
+"""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html)
+    return output_path
+
+
+def main():
+    args = parse_args()
+    default_end = date(2025, 8, 12)
+    default_start = date(2025, 8, 1)
+    start = to_date(args.start_date, default_start)
+    end = to_date(args.end_date, default_end)
+
+    rows = demo_rows()
+    # Note: For simplicity, demo data set already fixed to Aug 01-12; you can still filter by threshold.
+    rows = filter_rows(rows, args.threshold)
+
+    output = build_html(rows, args.output, start, end, args.threshold)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/volume_report/requirements.txt
+++ b/volume_report/requirements.txt
@@ -1,0 +1,7 @@
+pandas==2.2.2
+plotly==5.23.0
+SQLAlchemy==2.0.32
+pyodbc==5.1.0
+pymssql==2.3.1
+python-dotenv==1.0.1
+kaleido==0.2.1


### PR DESCRIPTION
Add a Python script to generate an interactive HTML report with website volume comparison charts from SQL Server, supporting dynamic dates and thresholds.

A dependency-free standalone script is also included to generate a demo report, as direct Python package installation was not possible in the environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e201826-3b48-4a50-9aa9-ff796061fd18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e201826-3b48-4a50-9aa9-ff796061fd18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

